### PR TITLE
Selective backend building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "3.0.0"
 dependencies = [
  "bindgen 0.14.0 (git+https://github.com/crabtw/rust-bindgen.git)",
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ libc = "*"
 git = "https://github.com/crabtw/rust-bindgen.git"
 version = "*"
 
+[build-dependencies.rustc-serialize]
+rustc-serialize = "*"
+
 [lib]
 name = "arrayfire"
-path = "src/arrayfire.rs"
+path = "src/lib.rs"
 
 [[test]]
 name = "arrayfire_test"
-path = "src/main.rs"
+path = "tests/hello_world.rs"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ In the future we will try to provide a nicer Rust-wrapped version of this header
 
 ## Building & Running
 
-Edit build.conf to modify the build flags. The structure is a simple JSON blob.
+Edit [build.conf](build.conf) to modify the build flags. The structure is a simple JSON blob.
 Currently Rust does not allow key:value pairs to be passed from the CLI.
-At the moment using an already installed arrayfire installation is not supported.
+At the moment using an exisiting arrayfire installation is not supported.
 
 To build:
 

--- a/README.md
+++ b/README.md
@@ -12,27 +12,23 @@ In the future we will try to provide a nicer Rust-wrapped version of this header
 
 ## Building & Running
 
-Currently the build script just builds the CUDA bindings.
-To change this edit build.rs (this will be changed to a Cargo variable eventually):
+Edit build.conf to modify the build flags. The structure is a simple JSON blob.
+Currently Rust does not allow key:value pairs to be passed from the CLI.
+At the moment using an already installed arrayfire installation is not supported.
 
-```rust
-run(cmake_cmd.arg("..")
-  .arg("-DCMAKE_BUILD_TYPE=Release")
-  .arg("-DBUILD_CUDA=ON")
-  .arg("-DBUILD_OPENCL=OFF")
-  .arg("-DBUILD_CPU=OFF"), "cmake");
-```
+To build:
 
 ```bash
 git submodule update --init --recursive
-cargo run
+cargo build
 ```
 
-You should see something along the lines of:
+To test:
 
 ```bash
-~/p/rust_arrayfire> cargo run
-     Running `target/debug/arrayfire`
+~/p/arrayfire_rust> cargo test
+...
+     running 1 test
 ArrayFire v3.0.0 (CUDA, 64-bit Mac OSX, build d8d4b38)
 Platform: CUDA Toolkit 7, Driver: CUDA Driver Version: 7000
 [0] GeForce GT 750M, 2048 MB, CUDA Compute 3.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In the future we will try to provide a nicer Rust-wrapped version of this header
 
 Edit [build.conf](build.conf) to modify the build flags. The structure is a simple JSON blob.
 Currently Rust does not allow key:value pairs to be passed from the CLI.
-At the moment using an exisiting arrayfire installation is not supported.
+To use an existing arrayfire installation modify the first three JSON values.
 
 To build:
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ Element-wise arithmetic
     0.8243     0.4531     0.3509
     0.7987     0.4910     0.6299
 ```
+
+## Issues
+
+You might see something along the lines of :
+
+```bash
+dyld: Library not loaded: @rpath/libafopencl.3.dylib
+```
+
+This is related to this (Rust issue)[https://github.com/rust-lang/rust/issues/25185]
+A workaround for now is to add the location of libaf*.dylib to your LD_LIBRARY_PATH.

--- a/build.conf
+++ b/build.conf
@@ -1,0 +1,13 @@
+{
+	"use_lib": false,
+	"lib_dir": "",
+	"inc_dir": "",
+
+	"release_type": "Release",
+	"make_flags": "-j8",
+	"build_cuda": "ON",
+	"build_opencl": "OFF",
+	"build_cpu": "ON",
+	"build_examples": "OFF",
+	"build_test": "OFF"
+}

--- a/build.conf
+++ b/build.conf
@@ -1,12 +1,12 @@
 {
 	"use_lib": false,
-	"lib_dir": "",
-	"inc_dir": "",
+	"lib_dir": "/usr/local/lib",
+	"inc_dir": "/usr/local/include",
 
 	"release_type": "Release",
 	"make_flags": "-j8",
-	"build_cuda": "ON",
-	"build_opencl": "OFF",
+	"build_cuda": "OFF",
+	"build_opencl": "ON",
 	"build_cpu": "ON",
 	"build_examples": "OFF",
 	"build_test": "OFF"

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ use bindgen::*; //dirty
 
 #[derive(RustcDecodable)]
 struct Config {
-  // TODO: Use these variables to pull in from path  
+  // Use the existing lib if it exists
   use_lib: bool,
   lib_dir: String,
   inc_dir: String,
@@ -30,40 +30,40 @@ struct Config {
 }
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(n) => n,
-        Err(e) => fail(&format!("\n{} failed with {}\n", stringify!($e), e)),
-    })
+  ($e:expr) => (match $e {
+    Ok(n) => n,
+    Err(e) => fail(&format!("\n{} failed with {}\n", stringify!($e), e)),
+  })
 }
 
 fn fail(s: &str) -> ! {
-    panic!("\n{}\n\nbuild script failed, must exit now", s)
+  panic!("\n{}\n\nbuild script failed, must exit now", s)
 }
 
 fn run(cmd: &mut Command, program: &str) {
-    println!("running: {:?}", cmd);
-    let status = match cmd.status() {
-        Ok(status) => status,
-        Err(ref e) if e.kind() == ErrorKind::NotFound => {
-            fail(&format!("failed to execute command: {}\nis `{}` not installed?",
-                          e, program));
-        }
-        Err(e) => fail(&format!("failed to execute command: {}", e)),
-    };
-    if !status.success() {
-        fail(&format!("command did not execute successfully, got: {}", status));
+  println!("running: {:?}", cmd);
+  let status = match cmd.status() {
+    Ok(status) => status,
+    Err(ref e) if e.kind() == ErrorKind::NotFound => {
+      fail(&format!("failed to execute command: {}\nis `{}` not installed?",
+                    e, program));
     }
+    Err(e) => fail(&format!("failed to execute command: {}", e)),
+  };
+  if !status.success() {
+    fail(&format!("command did not execute successfully, got: {}", status));
+  }
 }
 
 // Original CLI command: bindgen -l lib/libafcuda.dylib -I . -builtins -o arrayfire.rs arrayfire.h
 fn build_bindings(package_name: &str
-  , out_dir: &std::path::PathBuf
-  , arrayfire_dir: &std::path::PathBuf) 
+                  , out_dir: &std::path::PathBuf
+                  , include_path: &std::path::PathBuf) 
 {
   let rust_header = package_name.to_string() + ".rs";
   let c_header = package_name.to_string() + ".h";
 
-  let include_path = arrayfire_dir.join("include");
+  //let include_path = arrayfire_dir.join("include");
   let af_dir = include_path.join("af");
   
   let rs_dir = std::path::Path::new(&out_dir).join(rust_header);
@@ -88,10 +88,10 @@ fn build_bindings(package_name: &str
 fn read_file(file_name: &std::path::PathBuf) -> String {
   let file_path = file_name.to_str().unwrap();
   let options = OpenOptions::new()
-                    .read(true)
-                    .write(false)
-                    .create(false)
-                    .open(&file_path);
+    .read(true)
+    .write(false)
+    .create(false)
+    .open(&file_path);
   let mut file = match options {
     Ok(file) => file,
     Err(..) => panic!("error reading file"),
@@ -108,53 +108,84 @@ fn read_conf(conf_file: &std::path::PathBuf) -> Config {
   decoded
 }
 
-fn main() {
-    // Setup pathing
-    let src = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
-    let conf_file = src.join("build.conf");
-    let conf = read_conf(&conf_file);
+fn blob_backends(conf: &Config, build_dir: &std::path::PathBuf) -> (Vec<String>, Vec<String>){
+	let mut backend_dirs :Vec<String>= Vec::new();
+  let mut backends :Vec<String> = Vec::new();
 
+  if conf.build_cuda == "ON" {
+    backends.push("afcuda".to_string());
+    if !conf.use_lib {
+      backend_dirs.push(build_dir.join("src/backend/cuda").to_str().to_owned().unwrap().to_string());
+    }
+  }
+  if conf.build_opencl == "ON" {
+    backends.push("forge".to_string());
+    backends.push(("afopencl".to_string()));
+    if !conf.use_lib{
+      backend_dirs.push(build_dir.join("third_party/forge/lib").to_str().to_owned().unwrap().to_string());
+      backend_dirs.push(build_dir.join("src/backend/opencl").to_str().to_owned().unwrap().to_string());
+    }
+  }
+  if conf.build_cpu == "ON" {
+    backends.push("afcpu".to_string());
+    if !conf.use_lib{
+      backend_dirs.push(build_dir.join("src/backend/cpu").to_str().to_owned().unwrap().to_string());
+    }
+  }
+
+  if conf.use_lib{
+    backend_dirs.push(conf.lib_dir.to_owned());
+  }
+
+  return (backends, backend_dirs);
+}
+
+fn main() {
+  // Setup pathing
+  let src = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
+  let conf_file = src.join("build.conf");
+  let conf = read_conf(&conf_file);
+
+  let mut arrayfire_dir = src.join("arrayfire");
+  let build_dir = arrayfire_dir.join("build");
+  let src_dir = src.join("src");
+  
+  if !conf.use_lib {
     // create build directories
-    let arrayfire_dir = src.join("arrayfire");
-    let build_dir = arrayfire_dir.join("build");
-    let src_dir = src.join("src");
     let _ = fs::create_dir(&build_dir);
 
     // Run our cmake operations
     let mut cmake_cmd = Command::new("cmake");
     cmake_cmd.current_dir(&build_dir);
     run(cmake_cmd.arg("..")
-      .arg(format!("-DCMAKE_BUILD_TYPE={}", conf.release_type))
-      .arg(format!("-DBUILD_CUDA={}", conf.build_cuda))
-      .arg(format!("-DBUILD_OPENCL={}", conf.build_opencl))
-      .arg(format!("-DBUILD_EXAMPLES={}", conf.build_examples))
-      .arg(format!("-DBUILD_TEST={}", conf.build_test))
-      .arg(format!("-DBUILD_CPU={}", conf.build_cpu)), "cmake");
+        .arg(format!("-DCMAKE_BUILD_TYPE={}", conf.release_type))
+        .arg(format!("-DBUILD_CUDA={}", conf.build_cuda))
+        .arg(format!("-DBUILD_OPENCL={}", conf.build_opencl))
+        .arg(format!("-DBUILD_EXAMPLES={}", conf.build_examples))
+        .arg(format!("-DBUILD_TEST={}", conf.build_test))
+        .arg(format!("-DBUILD_CPU={}", conf.build_cpu)), "cmake");
 
     // run make
     let mut make_cmd = Command::new("make");
     make_cmd.current_dir(&build_dir);
-    run(make_cmd.arg(conf.make_flags), "make");
+    run(make_cmd.arg(conf.make_flags.to_owned()), "make");
+  }
 
-    // build correct backend
-    let mut backend_dir = String::new();
-    let mut backend = String::new();
-
-    if conf.build_cuda == "ON"{
-      backend = backend + "afcuda";
-      backend_dir = backend_dir + build_dir.join("src/backend/cuda").to_str().unwrap();
-    }else if conf.build_opencl == "ON"{
-      backend = backend + "afcl";
-      let cl_dir = format!("{}", build_dir.join("src/backend/opencl").to_str().unwrap());
-      backend_dir = backend_dir + &cl_dir;
-    }else if conf.build_cpu == "ON"{
-      backend = backend + "afcpu";
-      let cpu_dir = format!("{}", build_dir.join("src/backend/cpu").to_str().unwrap());
-      backend_dir = backend_dir + &cpu_dir;  
-    }
-
-    println!("cargo:rustc-link-search=native={}", backend_dir);
+  // build correct backend
+  let (backends, backend_dirs) = blob_backends(&conf, &build_dir);
+  for backend in backends.iter() {
     println!("cargo:rustc-link-lib=dylib={}", backend);
+  }
 
-    build_bindings("arrayfire", &src_dir, &arrayfire_dir);
+  for backend_dir in backend_dirs.iter() {
+    println!("cargo:rustc-link-search=native={}", backend_dir);
+  }
+
+  if conf.use_lib {
+    arrayfire_dir = PathBuf::from(conf.inc_dir);
+  }else{
+    arrayfire_dir = arrayfire_dir.join("include");
+  }
+  
+  build_bindings("arrayfire", &src_dir, &arrayfire_dir);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+extern crate libc;
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/arrayfire.rs"));

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 extern crate arrayfire;
 
+#[test]
 fn main() {
 	// Let's define a NULL var: 
 	// Rust does not like initializing dangling pointers


### PR DESCRIPTION
 - [x] Currently builds one of K backends using the build.conf file.
 - [x] Rust does not seem to support key:value pairs from the cargo CLI so this seems like the best workaround.
 - [x] Cleanup some hax

**TODO**: 
 - [x] Build N choose K backends. 
 - [x] Add logic for existing installations

