### PR TITLE
added option to build conf file to choose arrayfire backend

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -1,11 +1,13 @@
 {
+    "use_backend": "cuda",
+
     "use_lib": false,
     "lib_dir": "/usr/local/lib",
     "inc_dir": "/usr/local/include",
 
     "build_type": "Release",
     "build_threads": "4",
-    "build_cuda": "OFF",
+    "build_cuda": "ON",
     "build_opencl": "ON",
     "build_cpu": "ON",
     "build_examples": "OFF",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ use libc::c_longlong;
 use std::ops::Index;
 use std::ops::Add;
 
-#[link(name="afcpu")]
 extern {
     fn af_set_device(device: c_int) -> c_int;
 


### PR DESCRIPTION
Earlier, all the built backends of ArrayFire submodule were
linked with rust wrapper. This created issues when multiple backends
were linked at the same time.

This commit, adds the option `use_backend` to `build.conf` which
dictates the backend ([cpu | cuda | opencl]) used by the rust
wrapper irrespective of arrayfire backends built by the build script.
Subsequently, this ensures only rust crate currently built uses one
particular backend.