### PR TITLE
Added rust API for functions in af/algorithm.h

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -12,11 +12,11 @@ type AfArray    = ::libc::c_longlong;
 extern {
     fn af_sum(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
 
-    fn af_sum_nan(out: MutAfArray, input: AfArray, dim: c_int, nanval: c_double) -> c_int;
+    //fn af_sum_nan(out: MutAfArray, input: AfArray, dim: c_int, nanval: c_double) -> c_int;
 
     fn af_product(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
 
-    fn af_product_nan(out: MutAfArray, input: AfArray, dim: c_int, val: c_double) -> c_int;
+    //fn af_product_nan(out: MutAfArray, input: AfArray, dim: c_int, val: c_double) -> c_int;
 
     fn af_min(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
 
@@ -30,11 +30,11 @@ extern {
 
     fn af_sum_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
 
-    fn af_sum_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
+    //fn af_sum_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
 
     fn af_product_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
 
-    fn af_product_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
+    //fn af_product_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
 
     fn af_min_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
 
@@ -85,14 +85,14 @@ pub fn sum(input: &Array, dim: i32) -> Array {
     }
 }
 
-pub fn sum_nan(input: &Array, dim: i32, nanval: f64) -> Array {
-    unsafe {
-        let mut temp: i64 = 0;
-        af_sum_nan(&mut temp as MutAfArray, input.get() as AfArray,
-                   dim as c_int, nanval as c_double);
-        Array {handle: temp}
-    }
-}
+//pub fn sum_nan(input: &Array, dim: i32, nanval: f64) -> Array {
+//    unsafe {
+//        let mut temp: i64 = 0;
+//        af_sum_nan(&mut temp as MutAfArray, input.get() as AfArray,
+//                   dim as c_int, nanval as c_double);
+//        Array {handle: temp}
+//    }
+//}
 
 pub fn product(input: &Array, dim: i32) -> Array {
     unsafe {
@@ -102,14 +102,14 @@ pub fn product(input: &Array, dim: i32) -> Array {
     }
 }
 
-pub fn product_nan(input: &Array, dim: i32, nanval: f64) -> Array {
-    unsafe {
-        let mut temp: i64 = 0;
-        af_product_nan(&mut temp as MutAfArray, input.get() as AfArray,
-                       dim as c_int, nanval as c_double);
-        Array {handle: temp}
-    }
-}
+//pub fn product_nan(input: &Array, dim: i32, nanval: f64) -> Array {
+//    unsafe {
+//        let mut temp: i64 = 0;
+//        af_product_nan(&mut temp as MutAfArray, input.get() as AfArray,
+//                       dim as c_int, nanval as c_double);
+//        Array {handle: temp}
+//    }
+//}
 
 pub fn min(input: &Array, dim: i32) -> Array {
     unsafe {
@@ -161,15 +161,15 @@ pub fn sum_all(input: &Array) -> (f64, f64) {
     }
 }
 
-pub fn sum_nan_all(input: &Array, val: f64) -> (f64, f64) {
-    unsafe {
-        let mut real: f64 = 0.0;
-        let mut imag: f64 = 0.0;
-        af_sum_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
-                       input.get() as AfArray, val as c_double);
-        (real, imag)
-    }
-}
+//pub fn sum_nan_all(input: &Array, val: f64) -> (f64, f64) {
+//    unsafe {
+//        let mut real: f64 = 0.0;
+//        let mut imag: f64 = 0.0;
+//        af_sum_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
+//                       input.get() as AfArray, val as c_double);
+//        (real, imag)
+//    }
+//}
 
 pub fn product_all(input: &Array) -> (f64, f64) {
     unsafe {
@@ -181,15 +181,15 @@ pub fn product_all(input: &Array) -> (f64, f64) {
     }
 }
 
-pub fn product_nan_all(input: &Array, val: f64) -> (f64, f64) {
-    unsafe {
-        let mut real: f64 = 0.0;
-        let mut imag: f64 = 0.0;
-        af_product_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
-                           input.get() as AfArray, val as c_double);
-        (real, imag)
-    }
-}
+//pub fn product_nan_all(input: &Array, val: f64) -> (f64, f64) {
+//    unsafe {
+//        let mut real: f64 = 0.0;
+//        let mut imag: f64 = 0.0;
+//        af_product_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
+//                           input.get() as AfArray, val as c_double);
+//        (real, imag)
+//    }
+//}
 
 pub fn min_all(input: &Array) -> (f64, f64) {
     unsafe {

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -1,0 +1,373 @@
+extern crate libc;
+
+use super::Array as Array;
+use libc::{c_int, c_uint, c_double};
+
+type MutAfArray = *mut ::libc::c_longlong;
+type MutDouble  = *mut ::libc::c_double;
+type MutUint    = *mut ::libc::c_uint;
+type AfArray    = ::libc::c_longlong;
+
+#[allow(dead_code)]
+extern {
+    fn af_sum(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_sum_nan(out: MutAfArray, input: AfArray, dim: c_int, nanval: c_double) -> c_int;
+
+    fn af_product(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_product_nan(out: MutAfArray, input: AfArray, dim: c_int, val: c_double) -> c_int;
+
+    fn af_min(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_max(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_all_true(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_any_true(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_count(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_sum_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_sum_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
+
+    fn af_product_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_product_nan_all(r: MutDouble, i: MutDouble, input: AfArray, val: c_double) -> c_int;
+
+    fn af_min_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_max_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_all_true_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_any_true_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_count_all(r: MutDouble, i: MutDouble, input: AfArray) -> c_int;
+
+    fn af_imin(out: MutAfArray, idx: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_imax(out: MutAfArray, idx: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_imin_all(r: MutDouble, i: MutDouble, idx: MutUint, input: AfArray) -> c_int;
+
+    fn af_imax_all(r: MutDouble, i: MutDouble, idx: MutUint, input: AfArray) -> c_int;
+
+    fn af_accum(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_where(out: MutAfArray, input: AfArray) -> c_int;
+
+    fn af_diff1(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_diff2(out: MutAfArray, input: AfArray, dim: c_int) -> c_int;
+
+    fn af_sort(out: MutAfArray, input: AfArray, dim: c_uint, ascend: c_int) -> c_int;
+
+    fn af_sort_index(o: MutAfArray, i: MutAfArray, inp: AfArray, d: c_uint, a: c_int) -> c_int;
+
+    fn af_sort_by_key(out_keys: MutAfArray, out_vals: MutAfArray,
+                      in_keys: AfArray, in_vals: AfArray, dim: c_uint, ascend: c_int) -> c_int;
+
+    fn af_set_unique(out: MutAfArray, input: AfArray, is_sorted: c_int) -> c_int;
+
+    fn af_set_union(out: MutAfArray, first: AfArray, second: AfArray, is_unq: c_int) -> c_int;
+
+    fn af_set_intersect(out: MutAfArray, one: AfArray, two: AfArray, is_unq: c_int) -> c_int;
+}
+
+#[allow(unused_mut)]
+pub fn sum(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_sum(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn sum_nan(input: &Array, dim: i32, nanval: f64) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_sum_nan(&mut temp as MutAfArray, input.get() as AfArray,
+                   dim as c_int, nanval as c_double);
+        Array {handle: temp}
+    }
+}
+
+pub fn product(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_product(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn product_nan(input: &Array, dim: i32, nanval: f64) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_product_nan(&mut temp as MutAfArray, input.get() as AfArray,
+                       dim as c_int, nanval as c_double);
+        Array {handle: temp}
+    }
+}
+
+pub fn min(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_min(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn max(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_max(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn all_true(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_all_true(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn any_true(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_any_true(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn count(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_count(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn sum_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_sum_all(&mut real as MutDouble, &mut imag as MutDouble,
+                   input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn sum_nan_all(input: &Array, val: f64) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_sum_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
+                       input.get() as AfArray, val as c_double);
+        (real, imag)
+    }
+}
+
+pub fn product_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_product_all(&mut real as MutDouble, &mut imag as MutDouble,
+                       input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn product_nan_all(input: &Array, val: f64) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_product_nan_all(&mut real as MutDouble, &mut imag as MutDouble,
+                           input.get() as AfArray, val as c_double);
+        (real, imag)
+    }
+}
+
+pub fn min_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_min_all(&mut real as MutDouble, &mut imag as MutDouble,
+                   input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn max_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_max_all(&mut real as MutDouble, &mut imag as MutDouble,
+                   input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn all_true_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_all_true_all(&mut real as MutDouble, &mut imag as MutDouble,
+                        input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn any_true_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_any_true_all(&mut real as MutDouble, &mut imag as MutDouble,
+                        input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn count_all(input: &Array) -> (f64, f64) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        af_count_all(&mut real as MutDouble, &mut imag as MutDouble,
+                     input.get() as AfArray);
+        (real, imag)
+    }
+}
+
+pub fn imin(input: &Array, dim: i32) -> (Array, Array) {
+    unsafe {
+        let mut temp: i64 = 0;
+        let mut idx: i64 = 0;
+        af_imin(&mut temp as MutAfArray, &mut idx as MutAfArray,
+                input.get() as AfArray, dim as c_int);
+        (Array{handle: temp}, Array{handle: idx})
+    }
+}
+
+pub fn imax(input: &Array, dim: i32) -> (Array, Array) {
+    unsafe {
+        let mut temp: i64 = 0;
+        let mut idx: i64 = 0;
+        af_imax(&mut temp as MutAfArray, &mut idx as MutAfArray,
+                input.get() as AfArray, dim as c_int);
+        (Array{handle: temp}, Array{handle: idx})
+    }
+}
+
+pub fn imin_all(input: &Array) -> (f64, f64, u32) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        let mut temp: u32 = 0;
+        af_imin_all(&mut real as MutDouble, &mut imag as MutDouble,
+                    &mut temp as MutUint, input.get() as AfArray);
+        (real, imag, temp)
+    }
+}
+
+pub fn imax_all(input: &Array) -> (f64, f64, u32) {
+    unsafe {
+        let mut real: f64 = 0.0;
+        let mut imag: f64 = 0.0;
+        let mut temp: u32 = 0;
+        af_imax_all(&mut real as MutDouble, &mut imag as MutDouble,
+                    &mut temp as MutUint, input.get() as AfArray);
+        (real, imag, temp)
+    }
+}
+
+pub fn accum(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_accum(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn locate(input: &Array) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_where(&mut temp as MutAfArray, input.get() as AfArray);
+        Array {handle: temp}
+    }
+}
+
+pub fn diff1(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_diff1(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn diff2(input: &Array, dim: i32) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_diff2(&mut temp as MutAfArray, input.get() as AfArray, dim as c_int);
+        Array {handle: temp}
+    }
+}
+
+pub fn sort(input: &Array, dim: u32, ascending: bool) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_sort(&mut temp as MutAfArray, input.get() as AfArray,
+                dim as c_uint, ascending as c_int);
+        Array{handle: temp}
+    }
+}
+
+pub fn sort_index(input: &Array, dim: u32, ascending: bool) -> (Array, Array) {
+    unsafe {
+        let mut temp: i64 = 0;
+        let mut idx: i64 = 0;
+        af_sort_index(&mut temp as MutAfArray, &mut idx as MutAfArray,
+                      input.get() as AfArray,
+                      dim as c_uint, ascending as c_int);
+        (Array {handle: temp}, Array {handle: idx})
+    }
+}
+
+pub fn sort_by_key(keys: &Array, vals: &Array, dim: u32, ascending: bool) -> (Array, Array) {
+    unsafe {
+        let mut temp: i64 = 0;
+        let mut temp2: i64 = 0;
+        af_sort_by_key(&mut temp as MutAfArray, &mut temp2 as MutAfArray,
+                       keys.get() as AfArray, vals.get() as AfArray,
+                      dim as c_uint, ascending as c_int);
+        (Array {handle: temp}, Array {handle: temp2})
+    }
+}
+
+pub fn set_unique(input: &Array, is_sorted: bool) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_set_unique(&mut temp as MutAfArray, input.get() as AfArray, is_sorted as c_int);
+        Array{handle: temp}
+    }
+}
+
+pub fn set_union(first: &Array, second: &Array, is_unique: bool) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_set_union(&mut temp as MutAfArray, first.get() as AfArray,
+                     second.get() as AfArray, is_unique as c_int);
+        Array{handle: temp}
+    }
+}
+
+pub fn set_intersect(first: &Array, second: &Array, is_unique: bool) -> Array {
+    unsafe {
+        let mut temp: i64 = 0;
+        af_set_intersect(&mut temp as MutAfArray, first.get() as AfArray,
+                         second.get() as AfArray, is_unique as c_int);
+        Array{handle: temp}
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,8 +370,9 @@ pub fn fft3(input: &Array, norm_factor: f64, odim0: i64, odim1: i64, odim2: i64)
     }
 }
 
-pub use algorithm::{sum, sum_nan, product, product_nan, min, max, all_true, any_true, count};
-pub use algorithm::{sum_all, sum_nan_all, product_all, product_nan_all, min_all, max_all};
+//pub use algorithm::{sum_nan, product_nan, sum_nan_all, product_nan_all};
+pub use algorithm::{sum, product, min, max, all_true, any_true, count};
+pub use algorithm::{sum_all, product_all, min_all, max_all};
 pub use algorithm::{all_true_all, any_true_all, count_all, imin, imax, imin_all, imax_all};
 pub use algorithm::{accum, locate, diff1, diff2, sort, sort_index, sort_by_key};
 pub use algorithm::{set_unique, set_union, set_intersect};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,8 @@
 extern crate libc;
 
-use std::fmt;
-use libc::c_void;
-use libc::c_int;
-use libc::c_uint;
-use libc::c_double;
-use libc::c_longlong;
+use libc::{c_void, c_int, c_uint, c_double, c_longlong};
 
+use std::fmt;
 use std::ops::Index;
 use std::ops::Add;
 
@@ -81,12 +77,6 @@ extern {
                odim0: c_longlong,
                odim1: c_longlong,
                odim2: c_longlong) -> c_int;
-
-    fn af_sort_index(out: *mut c_longlong,
-                     indices: *mut c_longlong,
-                     input: c_longlong,
-                     dim: c_uint,
-                     ascending: c_int) -> c_int;
 }
 
 #[derive(Clone)]
@@ -380,16 +370,9 @@ pub fn fft3(input: &Array, norm_factor: f64, odim0: i64, odim1: i64, odim2: i64)
     }
 }
 
-#[allow(unused_mut)]
-pub fn sort(input: &Array, dim: u32, ascending: bool) -> (Array, Array) {
-    unsafe {
-        let mut temp: i64 = 0;
-        let mut idx: i64 = 0;
-        af_sort_index(&mut temp as *mut c_longlong,
-                      &mut idx as *mut c_longlong,
-                      input.get() as c_longlong,
-                      dim as c_uint,
-                      ascending as c_int);
-        (Array {handle: temp}, Array {handle: idx})
-    }
-}
+pub use algorithm::{sum, sum_nan, product, product_nan, min, max, all_true, any_true, count};
+pub use algorithm::{sum_all, sum_nan_all, product_all, product_nan_all, min_all, max_all};
+pub use algorithm::{all_true_all, any_true_all, count_all, imin, imax, imin_all, imax_all};
+pub use algorithm::{accum, locate, diff1, diff2, sort, sort_index, sort_by_key};
+pub use algorithm::{set_unique, set_union, set_intersect};
+mod algorithm;

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -43,7 +43,7 @@ fn main() {
 
     // // Sort A
     println!("Sort A and print sorted array and corresponding indices");
-    let (vals, inds) = af::sort(&a, 0, true);
+    let (vals, inds) = af::sort_index(&a, 0, true);
     af::print(&vals);
     af::print(&inds);
 }


### PR DESCRIPTION
All the C-API functions in `/af/algorithm.h` are in the
module `algorithm` which is re-exported from crate root
as if all functions are in the scope of crate `arrayfire`.